### PR TITLE
Use absolute path for file inclusion

### DIFF
--- a/wordpress-symfony-vardumper.php
+++ b/wordpress-symfony-vardumper.php
@@ -8,7 +8,7 @@
  * Version: 1.0.0
  */
 
-include( 'vendor/autoload.php' );
+include( dirname( __FILE__ ) . '/vendor/autoload.php' );
 
 $updatePhp = new WPUpdatePhp( '5.4.0' );
 


### PR DESCRIPTION
Prevents including the wrong file when people have `vendor/autoload.php` in their `include_path` already.
